### PR TITLE
Change approve/suspend buttons for platform admin

### DIFF
--- a/app/views/shared/_categories.html.erb
+++ b/app/views/shared/_categories.html.erb
@@ -1,6 +1,16 @@
 <%= link_to "Create New Category", new_category_path, class: "btn btn-success btn-font-size" %>
-<% @categories.each do |category| %>
-  <%= category.title %>
-  <%= link_to "Update Category", edit_category_path(category.slug), class: "btn btn-success btn-font-size" %>
-  <%= link_to "Delete Category", delete_category_path(category.slug), class: "btn btn-success btn-font-size", method: :delete %>
-<% end %>
+<table class="table">
+  <tr>
+    <th>Name</th>
+    <th></th>
+  </tr>
+    <% @categories.each do |category| %>
+      <tr>
+        <td><%= category.title %></td>
+        <td>
+          <%= link_to "Update Category", edit_category_path(category.slug), class: "btn btn-success btn-font-size" %>
+          <%= link_to "Delete Category", delete_category_path(category.slug), class: "btn btn-success btn-font-size", method: :delete %>
+        </td>
+      </tr>
+    <% end %>
+</table>

--- a/app/views/shared/_store_table.html.erb
+++ b/app/views/shared/_store_table.html.erb
@@ -2,21 +2,24 @@
   <tr>
     <th>Name</th>
     <th>Status</th>
+    <th></th>
   </tr>
   <% stores.each do |store| %>
     <tr>
       <td><%= link_to store.name, store_root_path(store.slug) %></td>
       <td><%= store.status.capitalize%></td>
       <td>
-        <%= form_for(store, method: :patch) do |f| %>
-          <input type="hidden" name="status" value="2">
-          <%= f.submit "Approve" %>
+        <% if store.status == "suspended" || store.status == "pending" %>
+          <%= form_for(store, method: :patch) do |f| %>
+            <input type="hidden" name="status" value="2">
+            <%= f.submit "Approve", class: "btn btn-success btn-font-size" %>
+          <% end %>
         <% end %>
-      </td>
-      <td>  
-        <%= form_for(store, method: :patch) do |f| %>
-          <input type="hidden" name="status" value="1">
-          <%= f.submit "Suspend" %>
+        <% if store.status == "approved" %>
+          <%= form_for(store, method: :patch) do |f| %>
+            <input type="hidden" name="status" value="1">
+            <%= f.submit "Suspend", class: "btn btn-danger btn-font-size" %>
+          <% end %>
         <% end %>
       </td>
     </tr>


### PR DESCRIPTION
- Only view approve button when store is pending or suspended
- Only view suspend button when store is approved
- cleaned up categories view in the platform admin dashboard
